### PR TITLE
workflow dispatchを削除

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,14 +5,8 @@ on:
         branches: ["main"]
     pull_request:
         branches: ["main"]
-    workflow_dispatch:
-        inputs:
-            whole_format:
-                type: boolean
-                description: プロジェクト全体をフォーマットするかどうか
-                default: false
-
-            
+        
+        
 env:
     DEVELOPER_DIR: /Applications/Xcode_16.0.app
 jobs:
@@ -28,10 +22,8 @@ jobs:
               uses: actions/checkout@v4
               with:
                 ref: ${{ github.event.pull_request.head.ref }}
-                fetch-depth: ${{ steps.pre_fetch_depth.outputs.depth }} # (PR の commits + 1) 個 checkout する              
-              
+                fetch-depth: ${{ steps.pre_fetch_depth.outputs.depth }} # (PR の commits + 1) 個 checkout する
             - name: Find swift files to format
-              if: inputs.whole_format == false
               run: |
                 SWIFT_FILES=()
                 while IFS="" read -r file; do SWIFT_FILES+=("${file}"); done < <(git diff --name-only --diff-filter=AMRC ${{ github.event.pull_request.base.sha }} -- "*.swift")
@@ -40,10 +32,6 @@ jobs:
                 else
                 swift format format --in-place --configuration .swift-format --parallel "${SWIFT_FILES[@]}" || true
                 fi
-            - name: All files to format
-              if: inputs.whole_format == true
-              run:   swift format format -r . --in-place --configuration .swift-format --parallel || true
-                
             - name: Commit and Push changes
               env:
                 HEAD_REF: ${{ github.head_ref }}


### PR DESCRIPTION
- 動作フロー的にPR下でないと対象ブランチが拾えないのでフラグでの分岐は不毛
- そもそも手動でフォーマットさせる機会がない